### PR TITLE
add map to ssl to use https encryption

### DIFF
--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -5,6 +5,7 @@
     "description": "InfluxDb server",
     "url": "https://github.com/bestlibre/hassio-addons/tree/master/influxdb",
     "startup": "system",
+    "map": ["ssl"],
     "boot": "auto",
     "image": "bestlibre/{arch}-influxdb",
     "options": {"env_var": []},


### PR DESCRIPTION
>> configuration
{
  "env_var": [
    {
      "name": "INFLUXDB_HTTP_AUTH_ENABLED",
      "value": "true"
    },
    {
      "name": "INFLUXDB_HTTP_HTTPS_ENABLED",
      "value": "true"
    },
    {
      "name": "INFLUXDB_HTTP_HTTPS_CERTIFICATE",
      "value": "/path/to/fullchain.pem"
    },
    {
      "name": "INFLUXDB_HTTP_HTTPS_PRIVATE_KEY",
      "value": "/path/to/privkey.pem"
    }
  ]
}
>> logs
[I] 2017-10-16T09:26:06Z Listening on HTTPS:[::]:8086 service=httpd
