### PR TITLE
nginx: Add support for basic auth

### DIFF
--- a/nginx_proxy/README.md
+++ b/nginx_proxy/README.md
@@ -26,6 +26,14 @@ Configure this vhost to be the default is set to true. Must only be used once.
 
 Ip or url for the proxified server. If not set default to 172.17.0.1 (docker host).
 
+#### auth (str)
+
+Enables HTTP basic auth for a single user on a vhost. The string is dumped
+directly to a file and used as the auth_basic_user_file. See the documentation
+for
+[auth_basic_user_file](http://nginx.org/en/docs/http/ngx_http_auth_basic_module.html#auth_basic_user_file)
+on how to format the value.
+
 #### certname (str)
 If not set, only http is proxified. If set, the template used for the vhosts force https. 
 

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,30 +1,30 @@
 {
-    "name": "Nginx Proxy",
-    "version": "0.1.7",
-    "slug": "nginx_proxy",
-    "description": "Nginx Proxy for multiple VHOSTS",
-    "url": "https://github.com/bestlibre/hassio-addons/tree/master/nginx_proxy",
-    "startup": "system",
-    "boot": "auto",
-    "image": "bestlibre/{arch}-nginx-proxy",
-    "options": {
-	"vhosts":[
-	    {"vhost": "homeassistant.domain.tld",
-	     "port": "8123",
-	     "default_server": true}
-	]
-    },
-    "schema": {
-	"vhosts": [
-	    {"vhost": "str",
-	     "remote": "str?",
-	     "port": "str",
-	     "default_server": "bool?",
-	     "certname": "str?",
-	     "ssl_modern": "bool?"
-	    }
-	]
-    },
-    "ports": {"80/tcp": 80, "443/tcp": 443},
-    "map": ["ssl"]
+  "name": "Nginx Proxy",
+  "version": "0.1.7",
+  "slug": "nginx_proxy",
+  "description": "Nginx Proxy for multiple VHOSTS",
+  "url": "https://github.com/bestlibre/hassio-addons/tree/master/nginx_proxy",
+  "startup": "system",
+  "boot": "auto",
+  "image": "bestlibre/{arch}-nginx-proxy",
+  "options": {
+    "vhosts":[
+      {"vhost": "homeassistant.domain.tld",
+       "port": "8123",
+       "default_server": true}
+    ]
+  },
+  "schema": {
+    "vhosts": [
+      {"vhost": "str",
+       "remote": "str?",
+       "port": "str",
+       "default_server": "bool?",
+       "certname": "str?",
+       "ssl_modern": "bool?",
+       "auth": "str?"}
+    ]
+  },
+  "ports": {"80/tcp": 80, "443/tcp": 443},
+  "map": ["ssl"]
 }

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Nginx Proxy",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "slug": "nginx_proxy",
   "description": "Nginx Proxy for multiple VHOSTS",
   "url": "https://github.com/bestlibre/hassio-addons/tree/master/nginx_proxy",

--- a/nginx_proxy/run.sh
+++ b/nginx_proxy/run.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 set -e
-ssl=$(jq -r '[.vhosts[] | .certname // empty] | if length > 0 then "true" else "false" end' /data/options.json)
+options="/data/options.json"
+ssl=$(jq -r '[.vhosts[] | .certname // empty] | if length > 0 then "true" else "false" end' $options)
 if [ "$ssl" == "true" ]; then
     if [ ! -e /data/dhparam.pem ]; then
         openssl dhparam -dsaparam -out /data/dhparam.pem 4096
     fi
 fi
+
+auths=$(jq -r '.vhosts[] | if .auth then .vhost + " " + .auth else empty end' $options)
+echo "$auths" | while read -r vhost auth; do
+    echo "$auth" >"/data/auth_$vhost"
+done
 
 mustache-cli /data/options.json /templates/vhost.mustache > /etc/nginx/conf.d/vhosts.conf
 

--- a/nginx_proxy/vhost.mustache
+++ b/nginx_proxy/vhost.mustache
@@ -3,14 +3,16 @@ server {
     server_name {{vhost}};
     listen 80 {{#default_server}}default_server{{/default_server}};
     listen [::]:80 {{#default_server}}default_server{{/default_server}};
+
     location ~ /.well-known {
         allow all;
-	root /ssl/wk/;
+        auth_basic off;
+        root /ssl/wk/;
     }
 {{#certname}}
 
     location / {
-	return 301 https://$host$request_uri;
+        return 301 https://$host$request_uri;
     }
 }
 
@@ -54,9 +56,15 @@ server {
 
     location ~ /.well-known {
         allow all;
-	root /ssl/wk/;
+        root /ssl/wk/;
     }
 {{/certname}}
+
+    {{#auth}}
+    auth_basic "password protected";
+    auth_basic_user_file /data/auth_{{vhost}};
+    {{/auth}}
+
     location / {
         proxy_pass http://{{#remote}}{{remote}}{{/remote}}{{^remote}}172.17.0.1{{/remote}}:{{port}};
     }


### PR DESCRIPTION
Here's an initial implementation of how to enable basic auth for a vhost. My usecase is to have basic auth (over HTTPS) on the internet-facing host, while just the dashboard password on LAN.

I can reduce the diff by leaving out the whitespace changes, if you wish.