### PR TITLE
Update config.json to avoid hassio warning

### DIFF
--- a/base_debian/config.json
+++ b/base_debian/config.json
@@ -2,6 +2,8 @@
     "name": "debian base image",
     "version": "stretch",
     "slug": "debian_base",
+    "boot": "auto",
+    "startup": "system",
     "image": "bestlibre/{arch}-debian-base",
     "description": "Base debian image with qemu_static. Not really an addon perse. To be used to create addons",
     "url": "https://github.com/bestlibre/hassio-addons/tree/master/base_debian",


### PR DESCRIPTION
Warning example

```
18-05-29 17:14:56 WARNING (MainThread) [hassio.addons.data] Can't read /data/addons/git/53caca22/base_debian/config.json: required key not provided @ data['boot']. Got None
required key not provided @ data['startup']. Got None
```