### PR TITLE
Dont force ssl redirects

### DIFF
--- a/nginx_proxy/README.md
+++ b/nginx_proxy/README.md
@@ -35,13 +35,16 @@ for
 on how to format the value.
 
 #### certname (str)
-If not set, only http is proxified. If set, the template used for the vhosts force https. 
+If not set, only http is proxified. If set and `keep_http_enabled` is not set to `true`, https is forced. 
 
 The key and certchain must be located in
 `/ssl/letsencrypt/live/${certname}/privkey.pem` and `/ssl/letsencrypt/live/${certname}/fullchain.pem`. A solution to obtain them is to used the [certbot addon](https://github.com/bestlibre/hassio-addons/tree/master/certbot).
 
 #### ssl_modern (bool)
 If certname is set, you can set this parameter to switch betwwen ssl profils. The profile are the ones defined by the [mozilla ssl config generator](https://mozilla.github.io/server-side-tls/ssl-config-generator/). Use the [modern one](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility) is set to `true`, the [intermediate one](https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28default.29) is set to `false`or not set.
+
+#### keep_http_enabled (bool)
+If certname is set, this option allows you to keep accepting http connections by setting this to `true`. Leaving the option out or setting it to `false` will redirect HTTP requests to the HTTPS equivalent.
 
 ## Usage exemple
 I proxyfy 4 services, 3 local to the pi, one on another host. My configs, for 4 subdomains, with two different certs (one for each physical hosts) are :

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Nginx Proxy",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "slug": "nginx_proxy",
   "description": "Nginx Proxy for multiple VHOSTS",
   "url": "https://github.com/bestlibre/hassio-addons/tree/master/nginx_proxy",
@@ -23,7 +23,8 @@
        "certname": "str?",
        "ssl_modern": "bool?",
        "auth": "str?",
-       "max_body_size": "str?"
+       "max_body_size": "str?",
+       "ssl_only": "bool?"
       }
     ]
   },

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -24,7 +24,7 @@
        "ssl_modern": "bool?",
        "auth": "str?",
        "max_body_size": "str?",
-       "ssl_only": "bool?"
+       "keep_http_enabled": "bool?"
       }
     ]
   },

--- a/nginx_proxy/vhost.mustache
+++ b/nginx_proxy/vhost.mustache
@@ -10,12 +10,12 @@ server {
         root /ssl/wk/;
     }
 {{#certname}}
-{{^ssl_only}}
+{{^keep_http_enabled}}
 
     location / {
         return 301 https://$host$request_uri;
     }
-{{/ssl_only}}
+{{/keep_http_enabled}}
 }
 
 server {

--- a/nginx_proxy/vhost.mustache
+++ b/nginx_proxy/vhost.mustache
@@ -10,10 +10,12 @@ server {
         root /ssl/wk/;
     }
 {{#certname}}
+{{^ssl_only}}
 
     location / {
         return 301 https://$host$request_uri;
     }
+{{/ssl_only}}
 }
 
 server {


### PR DESCRIPTION
This allows the user to choose, whether they want to allow HTTP requests, even though HTTPS is enabled. For backwards compatibility reasons, the option is turned off by default.

Sadly I'm not sure how to test this change without creating my own complete fork of the repo as the documentation is not clear about this detail.

I also made this a minor version change as it's a new feature and not a bugfix for me.