### PR TITLE
Added port 8088 as exposed port

### DIFF
--- a/influxdb/Dockerfile
+++ b/influxdb/Dockerfile
@@ -26,5 +26,6 @@ COPY run.sh /
 RUN chmod a+x /run.sh
 
 EXPOSE 8086
+EXPOSE 8088
 ENTRYPOINT [ "/run.sh" ]
 CMD ["influxd"]

--- a/influxdb/config.json
+++ b/influxdb/config.json
@@ -1,6 +1,6 @@
 {
     "name": "InfluxDb",
-    "version": "1.5.4",
+    "version": "1.5.5",
     "slug": "influxdb",
     "description": "InfluxDb server",
     "url": "https://github.com/bestlibre/hassio-addons/tree/master/influxdb",
@@ -8,8 +8,13 @@
     "map": ["ssl"],
     "boot": "auto",
     "image": "bestlibre/{arch}-influxdb",
-    "options": {"env_var": []},
+    "options": {
+        "env_var": [{
+            "name": "INFLUXDB_BIND_ADDRESS",
+            "value": ":8088"
+        }]
+    },
     "schema": {"env_var":[{"name": "str", "value": "str"}]},
-    "ports": {"8086/tcp": 8086},
+    "ports": {"8086/tcp": 8086, "8088/tcp": 8088},
     "arch": ["armhf", "amd64", "aarch64"]
 }


### PR DESCRIPTION
Added port 8088 as exposed port to be able to remote backup the database using `influxd backup` command.

## Related Issues

- https://github.com/bestlibre/hassio-addons/issues/85

## Changes

- Port 8088 has been added to Dockerfile as exposed port.
- `INFLUXDB_BIND_ADDRESS` environment property has been
added by default with 8088 as port value.
- Version number has been updated.