### PR TITLE
Fix Issue #116

### DIFF
--- a/nginx_proxy/vhost.mustache
+++ b/nginx_proxy/vhost.mustache
@@ -68,7 +68,7 @@ server {
     client_max_body_size {{max_body_size}};
     {{/max_body_size}}
     location / {
-        proxy_pass {{#remote_ssl}}https{{#remote_ssl}}{{^remote_ssl}}http{{/remote_ssl}://{{#remote}}{{remote}}{{/remote}}{{^remote}}172.17.0.1{{/remote}}:{{port}};
+        proxy_pass {{#remote_ssl}}https{{#remote_ssl}}{{^remote_ssl}}http{{/remote_ssl}}://{{#remote}}{{remote}}{{/remote}}{{^remote}}172.17.0.1{{/remote}}:{{port}};
         {{#x-ha-access}}proxy_set_header x-ha-access "{{x-ha-access}}";{{/x-ha-access}}
     }
 }

--- a/nginx_proxy/vhost.mustache
+++ b/nginx_proxy/vhost.mustache
@@ -68,7 +68,7 @@ server {
     client_max_body_size {{max_body_size}};
     {{/max_body_size}}
     location / {
-        proxy_pass {{#remote_ssl}}https{{#remote_ssl}}{{^remote_ssl}}http{{/remote_ssl}}://{{#remote}}{{remote}}{{/remote}}{{^remote}}172.17.0.1{{/remote}}:{{port}};
+        proxy_pass {{#remote_ssl}}https{{/remote_ssl}}{{^remote_ssl}}http{{/remote_ssl}}://{{#remote}}{{remote}}{{/remote}}{{^remote}}172.17.0.1{{/remote}}:{{port}};
         {{#x-ha-access}}proxy_set_header x-ha-access "{{x-ha-access}}";{{/x-ha-access}}
     }
 }


### PR DESCRIPTION
Missing closing curly brace

```
Traceback (most recent call last):
  File "/mustache.py", line 31, in <module>
    render(args.template, args.data)
  File "/mustache.py", line 23, in render
    print(renderer.render_path(template, context))
  File "/usr/local/lib/python3.7/site-packages/pystache/renderer.py", line 390, in render_path
    return self._render_string(template, *context, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pystache/renderer.py", line 402, in _render_string
    return self._render_final(render_func, *context, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pystache/renderer.py", line 419, in _render_final
    return render_func(engine, stack)
  File "/usr/local/lib/python3.7/site-packages/pystache/renderer.py", line 400, in <lambda>
    render_func = lambda engine, stack: engine.render(template, stack)
  File "/usr/local/lib/python3.7/site-packages/pystache/renderengine.py", line 179, in render
    parsed_template = parse(template, delimiters)
  File "/usr/local/lib/python3.7/site-packages/pystache/parser.py", line 41, in parse
    return parser.parse(template)
  File "/usr/local/lib/python3.7/site-packages/pystache/parser.py", line 320, in parse
    raise ParsingError("Section end tag mismatch: %s != %s" % (tag_key, section_key))
pystache.parser.ParsingError: Section end tag mismatch: remote_ssl}://{{#remote != remote_ssl
```