### PR TITLE
Update run.sh to allow newer config

### DIFF
--- a/syncthing/run.sh
+++ b/syncthing/run.sh
@@ -7,5 +7,5 @@ if [ ! -f '/data/config.xml' ]; then
     syncthing -generate=/data
     sed -i 's|<address>127.0.0.1:8384</address>|<address>:8384</address>|' /data/config.xml
 fi
-syncthing -no-browser -home=/data/
+syncthing -allow-newer-config -no-browser -home=/data/
 


### PR DESCRIPTION
The add-on no longer starts, with a warning that the configuration is at version 31 and cannot be higher than 30. I've tested this fix on my HA instance and it allows the add-on to skip this warning and start correctly.